### PR TITLE
Bugfix-notification-popup-queue-deletion

### DIFF
--- a/robot_framework/process.py
+++ b/robot_framework/process.py
@@ -31,9 +31,6 @@ def process(orchestrator_connection: OrchestratorConnection) -> None:
         elif process_arg == 'upload_and_handle_queue':
             # Delete all elements in the queue before uploading new ones
             base_dir = oc_args_json['base_dir']
-            queue_elements = orchestrator_connection.get_queue_elements("Databehandlingsaftale_Status_Queue")
-            for element in queue_elements:
-                orchestrator_connection.delete_queue_element(element.id)
 
             # Retrieve changes and upload
             orchestrator_connection.log_trace("Retrieving changes from overview.")
@@ -52,12 +49,6 @@ def process(orchestrator_connection: OrchestratorConnection) -> None:
         elif process_arg == 'queue_upload':
             # Delete all elements in the queue before uploading new ones
             base_dir = oc_args_json['base_dir']
-            while True:
-                queue_elements = orchestrator_connection.get_queue_elements("Databehandlingsaftale_Status_Queue")
-                if not queue_elements:
-                    break
-                for element in queue_elements:
-                    orchestrator_connection.delete_queue_element(element.id)
 
             orchestrator_connection.log_trace("Retrieving changes from overview.")
             approve_data, delete_data, wait_data = retrieve_changes(base_dir)
@@ -80,14 +71,3 @@ def process(orchestrator_connection: OrchestratorConnection) -> None:
 
     except ValueError as e:
         orchestrator_connection.log_trace(f"Value error: {str(e)}")
-
-
-if __name__ == '__main__':
-    import os
-    orchestrator_connection = OrchestratorConnection(
-        process_name="test.databehandling",
-        connection_string=os.getenv("OpenOrchestratorConnString"),
-        crypto_key=os.getenv("OpenOrchestratorKey"),
-        process_arguments='{"process":"handle_queue"}'
-    )
-    process(orchestrator_connection)

--- a/robot_framework/subprocesses/overview_creation.py
+++ b/robot_framework/subprocesses/overview_creation.py
@@ -12,7 +12,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import TimeoutException, NoSuchElementException, ElementClickInterceptedException, StaleElementReferenceException
+from selenium.common.exceptions import TimeoutException, NoSuchElementException, StaleElementReferenceException
 from openpyxl.worksheet.datavalidation import DataValidation
 
 
@@ -140,6 +140,7 @@ def add_columns_to_dataframe(file_path, instregnr, organisation):
 
 
 def wait_for_react_app(browser, timeout=10):
+    """Wait for react"""
     try:
         # Vent på at React-appen er fuldt indlæst
         WebDriverWait(browser, timeout).until(
@@ -160,6 +161,7 @@ def click_element_with_retries(
     retries=4,
     react_wait=True
 ):
+    """Click element with retries and wait for react"""
     for attempt in range(retries):
         try:
             # Ekstra React-ventetid hvis aktiveret

--- a/robot_framework/subprocesses/queue_handling.py
+++ b/robot_framework/subprocesses/queue_handling.py
@@ -5,10 +5,10 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import TimeoutException, NoSuchElementException, ElementClickInterceptedException, StaleElementReferenceException
+from selenium.common.exceptions import TimeoutException, NoSuchElementException, StaleElementReferenceException
 from OpenOrchestrator.database.queues import QueueStatus
-from .overview_creation import open_stil_connection
 from robot_framework.exceptions import handle_error
+from robot_framework.subprocesses.overview_creation import open_stil_connection
 
 MAX_RETRIES = 3
 RETRY_DELAY = 5
@@ -32,6 +32,7 @@ def process_queue_elements(queue_elements, orchestrator_connection):
 
 
 def wait_for_react_app(browser, timeout=10):
+    """ Wait for react """
     try:
         # Vent på at React-appen er fuldt indlæst
         WebDriverWait(browser, timeout).until(
@@ -52,6 +53,7 @@ def click_element_with_retries(
     retries=4,
     react_wait=True
 ):
+    """Attempt to click element with retries and react wait"""
     for attempt in range(retries):
         try:
             # Ekstra React-ventetid hvis aktiveret

--- a/robot_framework/subprocesses/queue_handling.py
+++ b/robot_framework/subprocesses/queue_handling.py
@@ -373,6 +373,7 @@ def enter_dataadministration(browser):
     print("Now trying to click 'Dataadministration' button")
     return click_element_with_retries(browser, By.XPATH, "/html/body/div[1]/div/div[2]/div[2]/div/div[2]/div/h3/a")
 
+
 def enter_organisation(browser, org, instregnr):
     """Navigate to the organization and click the necessary elements."""
     for attempt in range(MAX_RETRIES):

--- a/robot_framework/subprocesses/queue_handling.py
+++ b/robot_framework/subprocesses/queue_handling.py
@@ -18,6 +18,7 @@ DEFAULT_WAIT_TIME = 30
 def process_queue_elements(queue_elements, orchestrator_connection):
     """Process each queue element by grouping and handling them based on their reference type."""
     browser = webdriver.Chrome()
+    browser.maximize_window()
     try:
         open_stil_connection(browser)
         grouped_elements = group_elements_by_instregnr(queue_elements)
@@ -361,7 +362,7 @@ def enter_dataadministration(browser):
         )
         if notifications_close_button:
             close_notifications_popup(browser)
-            return True
+            print("Should have closed notification popup")
 
         if not browser.execute_script("return document.readyState") == "complete":
             browser.refresh()
@@ -369,8 +370,8 @@ def enter_dataadministration(browser):
 
     except TimeoutException:
         pass
+    print("Now trying to click 'Dataadministration' button")
     return click_element_with_retries(browser, By.XPATH, "/html/body/div[1]/div/div[2]/div[2]/div/div[2]/div/h3/a")
-
 
 def enter_organisation(browser, org, instregnr):
     """Navigate to the organization and click the necessary elements."""
@@ -406,8 +407,8 @@ def enter_organisation(browser, org, instregnr):
 def close_notifications_popup(browser):
     """Close any notification popups that may obstruct the automation process."""
     try:
-        WebDriverWait(browser, 5).until(
-            EC.element_to_be_clickable((By.ID, "udbyder-close-button"))
-        ).click()
+        print("Trying to close notification popup")
+        click_element_with_retries(browser, By.ID, "udbyder-close-button")
+
     except TimeoutException:
         print("No notification popup found or close button not clickable.")


### PR DESCRIPTION
Fix bug on notification popup. Previously interpreted notification close as entering dataadministration. Now not.
Remove deletion of queue on queue upload. Maintains old queue items for backtracing and statistics
